### PR TITLE
Add personal deployment files for SSEC gpu cluster

### DIFF
--- a/deploy/ssec/python.yml
+++ b/deploy/ssec/python.yml
@@ -1,0 +1,44 @@
+# Deployment file for SSEC GPU cluster.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: python
+  namespace: jnoss
+  labels:
+    app: python
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: python
+  template:
+    metadata:
+      labels:
+        app: python
+    spec:
+      containers:
+      - name: python
+        securityContext:
+          privileged: true
+        image: containers.repo.sciserver.org/jnoss/python:latest
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 8080
+        command:
+          - sleep
+          - "999999999"
+        resources:
+          limits:
+            nvidia.com/gpu: "1"
+        volumeMounts:
+        - mountPath: /sciserver/vc_crypt/ssec/jnoss
+          name: sciserver-mount
+          readOnly: false
+      nodeSelector:
+        nvidia.com/gpu.product: NVIDIA-A100-SXM4-80GB
+      volumes:
+        - name: sciserver-mount
+          nfs:
+            path: /srv/vc_crypt/ssec/jnoss
+            server: sciserver-fs1

--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -1,0 +1,30 @@
+# Dockerfile.python
+
+FROM python:3.11
+
+RUN ln -sf /bin/bash /bin/sh
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /
+COPY flfm/ /app/flfm
+COPY data/ /data
+COPY pyproject.toml /app/pyproject.toml
+
+COPY requirements/build.txt /build.txt
+COPY requirements/prd.txt /prd.txt
+
+RUN pip3 install -r prd.txt
+RUN pip3 install -r build.txt
+
+# Some extras.
+RUN pip3 install jax['cuda12']
+RUN pip3 install jupyter
+RUN pip3 install matplotlib
+
+# Build.
+RUN pip3 install -e app/
+
+# Expose a port to use with a jupyter notebook whilst we're here.
+# The port number is relatively arbitrary, here we use 8080.
+EXPOSE 8080

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ include = ["flfm*"]
 exclude = ["*.tests*"]
 
 [tool.setuptools_scm]
+fallback_version = "0.0.1"
+version_file = "flfm/_version.py"
 write_to = "flfm/_version.py"  # Replace flfm with actual name (it's just a template).
 
 [tool.bandit]


### PR DESCRIPTION
Timing the cli on our A100 GPU box we get an e2e rt of ~3.2s. (with ``jax['cuda12']`` installed).
```bash
time python app/flfm/cli.py data/yale/light_field_image.tif data/yale/measured_psf.tif reconstruction.tiff 230

real    0m3.241s
user    0m8.111s
sys     0m1.334s
```