### PR TITLE
[WIP] running the jax flfm code in java

### DIFF
--- a/flfm/cli.py
+++ b/flfm/cli.py
@@ -10,7 +10,7 @@ import flfm.restoration
 import flfm.util
 
 
-def main(
+def run(
     img: Path | str | io.BytesIO,
     psf: Path | str | io.BytesIO,
     out: Path | str | io.BytesIO,
@@ -42,5 +42,10 @@ def main(
     flfm.io.save(out, cropped)
 
 
+def export(out_path: str):
+    """Export the reconstruction function to a TensorFlow SavedModel."""
+    flfm.restoration.export_to_tf(out_path)
+
+
 if __name__ == "__main__":
-    fire.Fire(main)
+    fire.Fire({"run": run, "export": export})

--- a/flfm/cli.py
+++ b/flfm/cli.py
@@ -32,7 +32,7 @@ def run(
     psf = flfm.io.open(psf)
     lens_center = lens_center or (img.shape[-2] // 2, img.shape[-1] // 2)
 
-    reconstructed = flfm.restoration.richardson_lucy(img, psf, num_iter=num_iters)
+    reconstructed = flfm.restoration.reconstruct(img, psf, num_iter=num_iters)
     cropped = flfm.util.crop_and_apply_circle_mask(
         reconstructed,
         lens_center,

--- a/flfm/src/java/java_jax/pom.xml
+++ b/flfm/src/java/java_jax/pom.xml
@@ -12,24 +12,17 @@
    <maven.compiler.target>16</maven.compiler.target>
  </properties>
   <dependencies>
-    <!-- https://mvnrepository.com/artifact/org.tensorflow/tensorflow-core-api -->
-    <!-- <dependency>
-        <groupId>org.tensorflow</groupId>
-        <artifactId>tensorflow-core-api</artifactId>
-        <version>1.0.0</version>
-    </dependency> -->
-    <!-- https://mvnrepository.com/artifact/org.tensorflow/tensorflow-core-platform -->
     <dependency>
         <groupId>org.tensorflow</groupId>
         <artifactId>tensorflow-core-api</artifactId>
         <version>1.0.0</version>
     </dependency>
-    <!-- <dependency>
+    <dependency>
       <groupId>org.tensorflow</groupId>
       <artifactId>tensorflow-core-native</artifactId>
       <version>1.0.0</version>
       <classifier>linux-x86_64</classifier>
-    </dependency> -->
+    </dependency>
     <dependency>
       <groupId>org.tensorflow</groupId>
       <artifactId>tensorflow-core-native</artifactId>

--- a/flfm/src/java/java_jax/pom.xml
+++ b/flfm/src/java/java_jax/pom.xml
@@ -36,4 +36,99 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+
+      <plugin>
+        <!-- Build an executable JAR -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <classpathPrefix>lib/</classpathPrefix>
+              <mainClass>ssec_jhu.App</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+         <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <classpathPrefix>lib/</classpathPrefix>
+              <mainClass>ssec_jhu.App</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id> <!-- this is used for inheritance merges -->
+            <phase>package</phase> <!-- bind to the packaging phase -->
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>2.17</version>
+          <executions>
+              <execution>
+                  <id>validate</id>
+                  <phase>validate</phase>
+                  <configuration>
+                      <configLocation>google_checks.xml</configLocation>
+                      <!-- <suppressionsLocation>suppressions.xml
+                      </suppressionsLocation> -->
+                      <encoding>UTF-8</encoding>
+                      <failsOnError>true</failsOnError>
+                      <consoleOutput>true</consoleOutput>
+                      <includeTestSourceDirectory>true
+                      </includeTestSourceDirectory>
+                  </configuration>
+                  <goals>
+                      <goal>check</goal>
+                  </goals>
+              </execution>
+          </executions>
+        </plugin>
+
+      <plugin>
+        <groupId>com.theoryinpractise</groupId>
+        <artifactId>googleformatter-maven-plugin</artifactId>
+        <version>1.7.3</version>
+          <executions>
+            <execution>
+              <id>reformat-sources</id>
+              <configuration>
+                <includeStale>false</includeStale>
+                <style>GOOGLE</style>
+                <formatMain>true</formatMain>
+                <formatTest>true</formatTest>
+                <filterModified>false</filterModified>
+                <skip>false</skip>
+                <fixImports>false</fixImports>
+                <maxLineLength>100</maxLineLength>
+              </configuration>
+              <goals>
+                <goal>format</goal>
+              </goals>
+              <phase>process-sources</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/flfm/src/java/java_jax/pom.xml
+++ b/flfm/src/java/java_jax/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>ssec_jhu</groupId>
+  <artifactId>java_jax</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>java_jax</name>
+  <url>http://maven.apache.org</url>
+  <properties>
+   <maven.compiler.source>16</maven.compiler.source>
+   <maven.compiler.target>16</maven.compiler.target>
+ </properties>
+  <dependencies>
+    <!-- https://mvnrepository.com/artifact/org.tensorflow/tensorflow-core-api -->
+    <!-- <dependency>
+        <groupId>org.tensorflow</groupId>
+        <artifactId>tensorflow-core-api</artifactId>
+        <version>1.0.0</version>
+    </dependency> -->
+    <!-- https://mvnrepository.com/artifact/org.tensorflow/tensorflow-core-platform -->
+    <dependency>
+        <groupId>org.tensorflow</groupId>
+        <artifactId>tensorflow-core-api</artifactId>
+        <version>1.0.0</version>
+    </dependency>
+    <!-- <dependency>
+      <groupId>org.tensorflow</groupId>
+      <artifactId>tensorflow-core-native</artifactId>
+      <version>1.0.0</version>
+      <classifier>linux-x86_64</classifier>
+    </dependency> -->
+    <dependency>
+      <groupId>org.tensorflow</groupId>
+      <artifactId>tensorflow-core-native</artifactId>
+      <version>1.0.0</version>
+      <classifier>linux-x86_64-gpu</classifier>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/flfm/src/java/java_jax/src/main/java/ssec_jhu/App.java
+++ b/flfm/src/java/java_jax/src/main/java/ssec_jhu/App.java
@@ -1,0 +1,158 @@
+package ssec_jhu;
+
+import org.tensorflow.Tensor;
+import org.tensorflow.DeviceSpec;
+import org.tensorflow.EagerSession;
+import org.tensorflow.Graph;
+import org.tensorflow.Operand;
+import org.tensorflow.RawTensor;
+import org.tensorflow.Result;
+import org.tensorflow.SavedModelBundle;
+import org.tensorflow.Session;
+import org.tensorflow.ndarray.FloatNdArray;
+import org.tensorflow.ndarray.NdArray;
+import org.tensorflow.ndarray.NdArrays;
+import org.tensorflow.ndarray.StdArrays;
+import org.tensorflow.op.signal.Fft;
+import org.tensorflow.op.signal.Rfft;
+import org.tensorflow.op.signal.Rfft2d;
+import org.tensorflow.proto.ConfigProto;
+import org.tensorflow.proto.ConfigProtoOrBuilder;
+import org.tensorflow.proto.DataType;
+import org.tensorflow.proto.GPUOptions;
+import org.tensorflow.op.dtypes.Complex;
+import org.tensorflow.types.TFloat32;
+import org.tensorflow.types.TInt32;
+import org.tensorflow.op.Op;
+import org.tensorflow.op.Ops;
+import org.tensorflow.op.Scope;
+import org.tensorflow.op.core.Placeholder;
+import org.tensorflow.op.core.Reverse;
+
+import java.awt.desktop.OpenFilesEvent;
+import java.awt.image.BufferedImage;
+import java.io.IOError;
+import java.io.IOException;
+import java.nio.Buffer;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+
+/**
+ * Hello world!
+ *
+ */
+public class App
+{
+    private static FloatNdArray loadImageAsArray(String path) throws IOException {
+
+        System.out.println("Loading image from: " + path);
+
+        // Read the image file
+        ImageInputStream input = ImageIO.createImageInputStream(new java.io.File(path));
+        Iterator<ImageReader> readers = ImageIO.getImageReaders(input);
+
+        if (!readers.hasNext()) {
+            throw new IOException("No ImageReaders found for given file format.");
+        }
+
+        ImageReader reader = readers.next();
+        reader.setInput(input);
+
+        int numImages = reader.getNumImages(true);
+        System.out.println("Number of images: " + numImages);
+
+        BufferedImage[] images = new BufferedImage[numImages];
+        for (int i = 0; i < numImages; i++) {
+            images[i] = reader.read(i);
+        }
+
+        // Close the reader
+        reader.dispose();
+
+        // convert the image stack to a tensor
+        int n = numImages;
+        int h = images[0].getHeight();
+        int w = images[0].getWidth();
+        float[][][] imageData = new float[n][h][w];
+
+        for (int i = 0; i < n; i++) {
+            BufferedImage img = images[i];
+            for (int y = 0; y < h; y++) {
+                for (int x = 0; x < w; x++) {
+                    short value = (short) (img.getRGB(x, y) & 0xFFFF);
+                    imageData[i][y][x] = value / 65535f;
+                }
+            }
+        }
+
+        FloatNdArray imageArray = StdArrays.ndCopyOf(imageData);
+        System.out.println("Image loaded and converted to array. Shape: " + imageArray.shape());
+        return imageArray;
+    }
+
+    public static void main( String[] args )
+    {
+        System.out.println("CWD:" + System.getProperty("user.dir"));
+        String modelLocation = "./exported_model";
+
+        // Open a TIFF image
+        String imagePath = "./data/yale/light_field_image.tif";
+        String psfPath = "./data/yale/measured_psf.tif";
+
+        FloatNdArray image, psf, data;
+        try{
+            image = loadImageAsArray(imagePath);
+            psf = loadImageAsArray(psfPath);
+        } catch (IOException e) {
+            System.out.println("Error: " + e.getMessage());
+            throw new IOError(e);
+        }
+
+        data = NdArrays.ofFloats(psf.shape());
+        //fill data with 0.5f
+        for(int i = 0; i < data.shape().get(0); i++){
+            for(int j = 0; j < data.shape().get(1); j++){
+                for (int k = 0; k < data.shape().get(2); k++){
+                    data.setFloat(0.5f, i, j, k);
+                }
+            }
+        }
+
+        GPUOptions gpu = GPUOptions.newBuilder()
+                .setVisibleDeviceList("0")
+                .setPerProcessGpuMemoryFraction(0.8)
+                .setAllowGrowth(true)
+                .build();
+
+        ConfigProto configProto = ConfigProto.newBuilder()
+                .setAllowSoftPlacement(true)
+                .setLogDevicePlacement(true)
+                .mergeGpuOptions(gpu)
+                .build();
+
+        SavedModelBundle model = SavedModelBundle.loader(modelLocation).withConfigProto(configProto).load();
+
+        try (Tensor imageTensor = TFloat32.tensorOf(image);
+            Tensor psfTensor = TFloat32.tensorOf(psf);
+            Tensor dataTensor = TFloat32.tensorOf(data)
+        ){
+
+            Map<String, Tensor> inputs = new HashMap<String, Tensor>();
+            inputs.put("data", dataTensor);
+            inputs.put("image", imageTensor);
+            inputs.put("psf", psfTensor);
+
+            for (int i = 0; i < 10; i++){
+                System.out.println("Running model iter " + i);
+                Result result = model.function("serving_default").call(inputs);
+                inputs.replace("args_tf_0", result.get("output_0").get());
+            }
+        }
+        System.out.println("Done.");
+    }
+}

--- a/flfm/src/java/java_jax/src/main/java/ssec_jhu/App.java
+++ b/flfm/src/java/java_jax/src/main/java/ssec_jhu/App.java
@@ -37,6 +37,9 @@ import java.nio.Buffer;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.time.Duration;
+import java.time.Instant;
+
 
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
@@ -147,11 +150,14 @@ public class App
             inputs.put("image", imageTensor);
             inputs.put("psf", psfTensor);
 
+            System.out.println("Running model...");
+            Instant start = Instant.now();
             for (int i = 0; i < 10; i++){
-                System.out.println("Running model iter " + i);
                 Result result = model.function("serving_default").call(inputs);
                 inputs.replace("args_tf_0", result.get("output_0").get());
             }
+            Instant end = Instant.now();
+            System.out.println("Model run in " + (Duration.between(start, end).toMillis()/1000f) + "seconds");
         }
         System.out.println("Done.");
     }

--- a/flfm/src/java/java_jax/src/main/java/ssec_jhu/App.java
+++ b/flfm/src/java/java_jax/src/main/java/ssec_jhu/App.java
@@ -1,164 +1,137 @@
 package ssec_jhu;
 
 import org.tensorflow.Tensor;
-import org.tensorflow.DeviceSpec;
-import org.tensorflow.EagerSession;
-import org.tensorflow.Graph;
-import org.tensorflow.Operand;
-import org.tensorflow.RawTensor;
 import org.tensorflow.Result;
 import org.tensorflow.SavedModelBundle;
-import org.tensorflow.Session;
 import org.tensorflow.ndarray.FloatNdArray;
-import org.tensorflow.ndarray.NdArray;
 import org.tensorflow.ndarray.NdArrays;
 import org.tensorflow.ndarray.StdArrays;
-import org.tensorflow.op.signal.Fft;
-import org.tensorflow.op.signal.Rfft;
-import org.tensorflow.op.signal.Rfft2d;
 import org.tensorflow.proto.ConfigProto;
-import org.tensorflow.proto.ConfigProtoOrBuilder;
-import org.tensorflow.proto.DataType;
 import org.tensorflow.proto.GPUOptions;
-import org.tensorflow.op.dtypes.Complex;
 import org.tensorflow.types.TFloat32;
-import org.tensorflow.types.TInt32;
-import org.tensorflow.op.Op;
-import org.tensorflow.op.Ops;
-import org.tensorflow.op.Scope;
-import org.tensorflow.op.core.Placeholder;
-import org.tensorflow.op.core.Reverse;
 
-import java.awt.desktop.OpenFilesEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOError;
 import java.io.IOException;
-import java.nio.Buffer;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.time.Duration;
 import java.time.Instant;
 
-
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 
-/**
- * Hello world!
- *
- */
-public class App
-{
-    private static FloatNdArray loadImageAsArray(String path) throws IOException {
+public class App {
+  private static FloatNdArray loadImageAsArray(String path) throws IOException {
 
-        System.out.println("Loading image from: " + path);
+    System.out.println("Loading image from: " + path);
 
-        // Read the image file
-        ImageInputStream input = ImageIO.createImageInputStream(new java.io.File(path));
-        Iterator<ImageReader> readers = ImageIO.getImageReaders(input);
+    // Read the image file
+    ImageInputStream input = ImageIO.createImageInputStream(new java.io.File(path));
+    Iterator<ImageReader> readers = ImageIO.getImageReaders(input);
 
-        if (!readers.hasNext()) {
-            throw new IOException("No ImageReaders found for given file format.");
-        }
-
-        ImageReader reader = readers.next();
-        reader.setInput(input);
-
-        int numImages = reader.getNumImages(true);
-        System.out.println("Number of images: " + numImages);
-
-        BufferedImage[] images = new BufferedImage[numImages];
-        for (int i = 0; i < numImages; i++) {
-            images[i] = reader.read(i);
-        }
-
-        // Close the reader
-        reader.dispose();
-
-        // convert the image stack to a tensor
-        int n = numImages;
-        int h = images[0].getHeight();
-        int w = images[0].getWidth();
-        float[][][] imageData = new float[n][h][w];
-
-        for (int i = 0; i < n; i++) {
-            BufferedImage img = images[i];
-            for (int y = 0; y < h; y++) {
-                for (int x = 0; x < w; x++) {
-                    short value = (short) (img.getRGB(x, y) & 0xFFFF);
-                    imageData[i][y][x] = value / 65535f;
-                }
-            }
-        }
-
-        FloatNdArray imageArray = StdArrays.ndCopyOf(imageData);
-        System.out.println("Image loaded and converted to array. Shape: " + imageArray.shape());
-        return imageArray;
+    if (!readers.hasNext()) {
+      throw new IOException("No ImageReaders found for given file format.");
     }
 
-    public static void main( String[] args )
-    {
-        System.out.println("CWD:" + System.getProperty("user.dir"));
-        String modelLocation = "./exported_model";
+    ImageReader reader = readers.next();
+    reader.setInput(input);
 
-        // Open a TIFF image
-        String imagePath = "./data/yale/light_field_image.tif";
-        String psfPath = "./data/yale/measured_psf.tif";
+    int numImages = reader.getNumImages(true);
+    System.out.println("Number of images: " + numImages);
 
-        FloatNdArray image, psf, data;
-        try{
-            image = loadImageAsArray(imagePath);
-            psf = loadImageAsArray(psfPath);
-        } catch (IOException e) {
-            System.out.println("Error: " + e.getMessage());
-            throw new IOError(e);
-        }
-
-        data = NdArrays.ofFloats(psf.shape());
-        //fill data with 0.5f
-        for(int i = 0; i < data.shape().get(0); i++){
-            for(int j = 0; j < data.shape().get(1); j++){
-                for (int k = 0; k < data.shape().get(2); k++){
-                    data.setFloat(0.5f, i, j, k);
-                }
-            }
-        }
-
-        GPUOptions gpu = GPUOptions.newBuilder()
-                .setVisibleDeviceList("0")
-                .setPerProcessGpuMemoryFraction(0.8)
-                .setAllowGrowth(true)
-                .build();
-
-        ConfigProto configProto = ConfigProto.newBuilder()
-                .setAllowSoftPlacement(true)
-                .setLogDevicePlacement(true)
-                .mergeGpuOptions(gpu)
-                .build();
-
-        SavedModelBundle model = SavedModelBundle.loader(modelLocation).withConfigProto(configProto).load();
-
-        try (Tensor imageTensor = TFloat32.tensorOf(image);
-            Tensor psfTensor = TFloat32.tensorOf(psf);
-            Tensor dataTensor = TFloat32.tensorOf(data)
-        ){
-
-            Map<String, Tensor> inputs = new HashMap<String, Tensor>();
-            inputs.put("data", dataTensor);
-            inputs.put("image", imageTensor);
-            inputs.put("psf", psfTensor);
-
-            System.out.println("Running model...");
-            Instant start = Instant.now();
-            for (int i = 0; i < 10; i++){
-                Result result = model.function("serving_default").call(inputs);
-                inputs.replace("args_tf_0", result.get("output_0").get());
-            }
-            Instant end = Instant.now();
-            System.out.println("Model run in " + (Duration.between(start, end).toMillis()/1000f) + "seconds");
-        }
-        System.out.println("Done.");
+    BufferedImage[] images = new BufferedImage[numImages];
+    for (int i = 0; i < numImages; i++) {
+      images[i] = reader.read(i);
     }
+
+    // Close the reader
+    reader.dispose();
+
+    // convert the image stack to a tensor
+    int n = numImages;
+    int h = images[0].getHeight();
+    int w = images[0].getWidth();
+    float[][][] imageData = new float[n][h][w];
+
+    for (int i = 0; i < n; i++) {
+      BufferedImage img = images[i];
+      for (int y = 0; y < h; y++) {
+        for (int x = 0; x < w; x++) {
+          short value = (short) (img.getRGB(x, y) & 0xFFFF);
+          imageData[i][y][x] = value / 65535f;
+        }
+      }
+    }
+
+    FloatNdArray imageArray = StdArrays.ndCopyOf(imageData);
+    System.out.println("Image loaded and converted to array. Shape: " + imageArray.shape());
+    return imageArray;
+  }
+
+  public static void main(String[] args) {
+    System.out.println("CWD:" + System.getProperty("user.dir"));
+    String modelLocation = "./exported_model";
+
+    // Open a TIFF image
+    String imagePath = "./data/yale/light_field_image.tif";
+    String psfPath = "./data/yale/measured_psf.tif";
+
+    FloatNdArray image, psf, data;
+    try {
+      image = loadImageAsArray(imagePath);
+      psf = loadImageAsArray(psfPath);
+    } catch (IOException e) {
+      System.out.println("Error: " + e.getMessage());
+      throw new IOError(e);
+    }
+
+    data = NdArrays.ofFloats(psf.shape());
+    // fill data with 0.5f
+    for (int i = 0; i < data.shape().get(0); i++) {
+      for (int j = 0; j < data.shape().get(1); j++) {
+        for (int k = 0; k < data.shape().get(2); k++) {
+          data.setFloat(0.5f, i, j, k);
+        }
+      }
+    }
+
+    GPUOptions gpu =
+        GPUOptions.newBuilder()
+            .setVisibleDeviceList("0")
+            .setPerProcessGpuMemoryFraction(0.8)
+            .setAllowGrowth(true)
+            .build();
+
+    ConfigProto configProto =
+        ConfigProto.newBuilder()
+            .setAllowSoftPlacement(true)
+            .setLogDevicePlacement(true)
+            .mergeGpuOptions(gpu)
+            .build();
+
+    SavedModelBundle model =
+        SavedModelBundle.loader(modelLocation).withConfigProto(configProto).load();
+
+    try (Tensor imageTensor = TFloat32.tensorOf(image);
+        Tensor psfTensor = TFloat32.tensorOf(psf);
+        Tensor dataTensor = TFloat32.tensorOf(data)) {
+
+      Map<String, Tensor> inputs = new HashMap<String, Tensor>();
+      inputs.put("data", dataTensor);
+      inputs.put("image", imageTensor);
+      inputs.put("psf", psfTensor);
+
+      System.out.println("Running model...");
+      Instant start = Instant.now();
+      Result result = model.function("serving_default").call(inputs);
+      Tensor output = result.get("output_0").get();
+      Instant end = Instant.now();
+      System.out.println(
+          "Model run in " + (Duration.between(start, end).toMillis() / 1000f) + "seconds");
+    }
+    System.out.println("Done.");
+  }
 }

--- a/flfm/src/java/java_jax/src/test/java/ssec_jhu/AppTest.java
+++ b/flfm/src/java/java_jax/src/test/java/ssec_jhu/AppTest.java
@@ -4,35 +4,24 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
-/**
- * Unit test for simple App.
- */
-public class AppTest 
-    extends TestCase
-{
-    /**
-     * Create the test case
-     *
-     * @param testName name of the test case
-     */
-    public AppTest( String testName )
-    {
-        super( testName );
-    }
+/** Unit test for simple App. */
+public class AppTest extends TestCase {
+  /**
+   * Create the test case
+   *
+   * @param testName name of the test case
+   */
+  public AppTest(String testName) {
+    super(testName);
+  }
 
-    /**
-     * @return the suite of tests being tested
-     */
-    public static Test suite()
-    {
-        return new TestSuite( AppTest.class );
-    }
+  /** @return the suite of tests being tested */
+  public static Test suite() {
+    return new TestSuite(AppTest.class);
+  }
 
-    /**
-     * Rigourous Test :-)
-     */
-    public void testApp()
-    {
-        assertTrue( true );
-    }
+  /** Rigourous Test :-) */
+  public void testApp() {
+    assertTrue(true);
+  }
 }

--- a/flfm/src/java/java_jax/src/test/java/ssec_jhu/AppTest.java
+++ b/flfm/src/java/java_jax/src/test/java/ssec_jhu/AppTest.java
@@ -1,0 +1,38 @@
+package ssec_jhu;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+    extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public AppTest( String testName )
+    {
+        super( testName );
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite( AppTest.class );
+    }
+
+    /**
+     * Rigourous Test :-)
+     */
+    public void testApp()
+    {
+        assertTrue( true );
+    }
+}

--- a/flfm/tests/test_integration.py
+++ b/flfm/tests/test_integration.py
@@ -81,7 +81,7 @@ def test_cli(tmp_path) -> None:
 
     out_stream = tmp_path / "test_file.tiff"
 
-    flfm.cli.main(
+    flfm.cli.run(
         img=rand_img_stream,
         psf=sim_psf_stream,
         out=out_stream,

--- a/flfm/tests/test_integration.py
+++ b/flfm/tests/test_integration.py
@@ -43,7 +43,7 @@ def test_simple_integration() -> None:
     psf = flfm.io.open(sim_psf_stream)
 
     # reconstruct the image
-    reconstructed = flfm.restoration.richardson_lucy(img, psf, num_iter=1)
+    reconstructed = flfm.restoration.reconstruct(img, psf, num_iter=1)
 
     # save the reconstructed image to a byte stream
     out_stream = io.BytesIO()

--- a/flfm/tests/test_restoration.py
+++ b/flfm/tests/test_restoration.py
@@ -7,5 +7,5 @@ class TestRichardsonLucy:
     def test_2d_image(self):
         image = flfm.io.open(flfm.util.find_repo_location() / "data/yale/light_field_image.tif")
         psf = flfm.io.open(flfm.util.find_repo_location() / "data/yale/measured_psf.tif")
-        recon = flfm.restoration.richardson_lucy(image, psf[21])
+        recon = flfm.restoration.reconstruct(image, psf[21])
         assert recon.shape == image.shape


### PR DESCRIPTION
Because the Plugin will be in java running the model in java would simplify calling the jax implementation from the plugin.

Tensorflow has some jvm support:

https://www.tensorflow.org/jvm

Jax and tensorflow are both google products and play nicely together. We might be able to export the jax function to tensorflow and run it in java using tensorflow.

- [x] get it working on jvm
  - [x] for cpu
  - [x] for gpu
- [x] improve perf on gpu
- [x] write exporter
- [x] resolve tensorflow wanting numpy<2.2 (Punted to #152)
- [ ] perf on A100 (Can be puntted to #124)
- [x] Add Self-contained end-to-end example using Docker.
  - [ ] Image saving output inside container (punted to #153)
- [ ] add unitests
  - [x] python
  - [ ] java (may dep. on #117) 