### PR TITLE
Add perf options to pass preprocessed PSF to RL function

### DIFF
--- a/data/ssec/reconstructed_image.tif
+++ b/data/ssec/reconstructed_image.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbb580105ebbda4178132c060602cac440934239c49663c6df3c89e5dca32f05
+size 34708304

--- a/flfm/tests/test_restoration.py
+++ b/flfm/tests/test_restoration.py
@@ -1,6 +1,14 @@
+import time
+
+import jax.numpy as jnp
+import numpy as np
+
 import flfm.io
 import flfm.restoration
 import flfm.util
+
+CENTER = [1000, 980]
+RADIUS = 230
 
 
 class TestRichardsonLucy:
@@ -9,3 +17,40 @@ class TestRichardsonLucy:
         psf = flfm.io.open(flfm.util.find_repo_location() / "data/yale/measured_psf.tif")
         recon = flfm.restoration.richardson_lucy(image, psf[21])
         assert recon.shape == image.shape
+
+
+class TestPerformance:
+    def test_3d_reconstruction(self):
+        image = flfm.io.open(flfm.util.find_repo_location() / "data/yale/light_field_image.tif")
+        psf = flfm.io.open(flfm.util.find_repo_location() / "data/yale/measured_psf.tif")
+        psf /= jnp.sum(psf, axis=(1, 2), keepdims=True)
+        t0 = time.time()
+        recon = flfm.restoration.richardson_lucy(image, psf, wait=True)
+        print(f"test_3d_reconstruction RT: {int((time.time() - t0) * 1e3)}ms")
+        assert recon.shape == psf.shape
+
+        truth = flfm.io.open(flfm.util.find_repo_location() / "data/ssec/reconstructed_image.tif")
+        cropped = flfm.util.crop_and_apply_circle_mask(recon, center=CENTER, radius=RADIUS)
+        assert np.isclose(truth, cropped).all()
+
+    def test_3d_reconstruction_perf(self):
+        image = flfm.io.open(flfm.util.find_repo_location() / "data/yale/light_field_image.tif")
+        psf = flfm.io.open(flfm.util.find_repo_location() / "data/yale/measured_psf.tif")
+        psf /= jnp.sum(psf, axis=(1, 2), keepdims=True)
+
+        # Precompute the FFT of the PSFs
+        psf_fft = jnp.fft.rfft2(psf, axes=(-2, -1))
+        psft_fft = jnp.fft.rfft2(jnp.flip(psf, axis=(-2, -1)))
+
+        initial_guess = jnp.ones_like(psf) * 0.5
+
+        t0 = time.time()
+        recon = flfm.restoration.richardson_lucy(
+            image, psf=None, initial_guess=initial_guess, psf_fft=psf_fft, psft_fft=psft_fft, wait=True
+        )
+        print(f"test_3d_reconstruction_perf RT: {int((time.time() - t0) * 1e3)}ms")
+        assert recon.shape == psf.shape
+
+        truth = flfm.io.open(flfm.util.find_repo_location() / "data/ssec/reconstructed_image.tif")
+        cropped = flfm.util.crop_and_apply_circle_mask(recon, center=CENTER, radius=RADIUS)
+        assert np.isclose(truth, cropped).all()


### PR DESCRIPTION
``data/ssec/reconstructed_image.tif`` was created using the Python implementation but not from this PR but from ``main``. We compare against the Python reconstruction due to  #74.

>[!NOTE]
> CI now takes ~10min to run.

We may want to skip one or both tests for CI.

This also resolves #71.