### PR TITLE
Update README install instructions for torch vs jax

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,12 @@ For additional cmds see the [Conda cheat-sheet](https://docs.conda.io/projects/c
   > using: ``pip install -e .[dev]``.
   
   >[!NOTE]
-  > For Nvidia GPU utilization install ``jax["cuda12"]``, e.g., ``pip install jax["cuda12"]``.
-  > See the [JAX installation docs](https://docs.jax.dev/en/latest/installation.html#installation) for further details
-  > on supported hardware accelerator architectures and operating systems.
+  > For GPU acceleration either PyTorch or JAX can be re-installed with their accelerator options.
+  > For PyTorch see the [PyTorch installation docs](https://pytorch.org/get-started/locally/).
+  > E.g., ``pip install --force torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126``.
+  > For JAX see the [JAX installation docs](https://docs.jax.dev/en/latest/installation.html#installation).
+  > E.g., ``pip install --force jax["cuda12"]``. Since both are installed via ``requirements/prd.txt``, ``--force`` must
+  > be used to re-install the accelerator versions.
 
   #### with Docker (C++ version only):
   * Download & install Docker - see [Docker install docs](https://docs.docker.com/get-docker/).
@@ -70,7 +73,7 @@ Follow the above [Build with Python ecosystem instructions](#with-python-ecosyst
 
 Using the command line interface (i.e., from a terminal prompt):
 ```term
-python flfm/cli.py data/yale/light_field_image.tif data/yale/measured_psf.tif reconstructed_image.tiff --lens_radius=230 --lens_center="(1000,980)"
+python flfm/cli.py data/yale/light_field_image.tif data/yale/measured_psf.tif reconstructed_image.tiff --lens_radius=230 --lens_center="(1000,980)" --backend=torch
 ```
 
 Within a Python session or Jupyter notebook:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "jax",
     "numpy",
     "pillow",
+    "torch",
+    "torchaudio",
+    "torchvision"
 ]
 
 [project.optional-dependencies]

--- a/requirements/prd.txt
+++ b/requirements/prd.txt
@@ -2,3 +2,6 @@ fire==0.7.0
 jax==0.5.1
 numpy==2.2.4
 pillow==11.1.0
+torch==2.6.0
+torchaudio==2.6.0
+torchvision==0.21.0

--- a/requirements/pytorch.txt
+++ b/requirements/pytorch.txt
@@ -1,4 +1,0 @@
--i https://download.pytorch.org/whl/cpu
-torch==2.6.0
-torchaudio==2.6.0
-torchvision==0.21.0

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,6 @@ deps =
     -r requirements/test.txt
     -r requirements/prd.txt
 commands=
-    pip install -r requirements/pytorch.txt
     pytest --cov=./ --cov-report=html:coverage.html --cov-report=xml:coverage.xml {posargs}
 
 [testenv:build-docs]


### PR DESCRIPTION
@ryanhausen Sorry I missid this in #134.

Given that pyTorch works on more OSs than JAX, I think we should make _it_ the default. Thoughts?