### PR TITLE
Fix pytest failure due to import name missmatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,9 @@ exclude = [
 ]
 target-version = "py311"
 
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
+
 [tool.ruff.lint.pydocstyle] # https://docs.astral.sh/ruff/settings/#lint_pydocstyle_convention
 convention = "google"
 


### PR DESCRIPTION
No idea why this started failing for me locally. I tried downgrading and recently upgraded related packages and still it remained broken.

See https://stackoverflow.com/questions/53918088/import-file-mismatch-in-pytest