### PR TITLE
192 add batch feature to cli

### DIFF
--- a/flfm/batch.py
+++ b/flfm/batch.py
@@ -15,6 +15,7 @@ def batch_reconstruction(
     input_dir: str | Path,
     output_dir: str | Path,
     psf_filename: str | Path,
+    filename_pattern: str = "*",
     normalize_psf: bool = True,
     n_workers: Optional[int] = None,
     n_threads: int = 2,
@@ -29,6 +30,7 @@ def batch_reconstruction(
         input_dir: Input directory.
         output_dir: Output directory.
         psf_filename: PSF filename.
+        filename_pattern: input filename glob pattern. Defaults to "*".
         normalize_psf: Whether to normalize PSF before reconstruction. Defaults to True.
         n_workers: Numbers of parallel workers.  Defaults to None.
         n_threads: Number of threads per worker.  Defaults to 2.
@@ -46,7 +48,7 @@ def batch_reconstruction(
     output_dir.mkdir(parents=True, exist_ok=clobber or carry_on)
 
     input_dir = Path(input_dir)
-    input_filenames = flfm.util.find_files(input_dir)
+    input_filenames = list(input_dir.glob(filename_pattern))
 
     if not input_filenames:
         raise FileNotFoundError(f"No input files found in {input_dir}")
@@ -54,7 +56,7 @@ def batch_reconstruction(
     psf_filename = Path(psf_filename)
 
     if carry_on:
-        existing_output_files = [x.name for x in flfm.util.find_files(output_dir)]
+        existing_output_files = [x.name for x in output_dir.glob(filename_pattern)]
         n_input_files = len(input_filenames)
         input_filenames = [x for x in input_filenames if x.name not in existing_output_files]
         print(f"Carrying on batch processing at {len(input_filenames)}/{n_input_files}.")
@@ -70,7 +72,7 @@ def batch_reconstruction(
         futures = []
         for i, filename in enumerate(input_filenames):
             print(f"({i + 1}/{len(input_filenames)}): Processing '{filename}'...")
-            output_filename = output_dir / filename
+            output_filename = output_dir / filename.name
             future = client.submit(
                 flfm.restoration.reconstruct,
                 psf_filename,

--- a/flfm/batch.py
+++ b/flfm/batch.py
@@ -48,6 +48,9 @@ def batch_reconstruction(
     input_dir = Path(input_dir)
     input_filenames = flfm.util.find_files(input_dir)
 
+    if not input_filenames:
+        raise FileNotFoundError(f"No input files found in {input_dir}")
+
     psf_filename = Path(psf_filename)
 
     if carry_on:

--- a/flfm/cli.py
+++ b/flfm/cli.py
@@ -31,6 +31,16 @@ def import_backend(backend: str) -> None:
         print(BACKEND_SUCCESS.format(backend=backend))
 
 
+def exception_handler(func):
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as error:
+            print(error)
+    return wrapper
+
+
+@exception_handler
 def main(
     img: str | Path | io.BytesIO,
     psf: str | Path | io.BytesIO,
@@ -76,6 +86,7 @@ def main(
     flfm.io.save(out, cropped)
 
 
+@exception_handler
 def export(
     out: str | Path | io.BytesIO,
     n_steps: int,
@@ -106,6 +117,7 @@ def export(
     )
 
 
+@exception_handler
 def batch(
         input_dir: str | Path,
         output_dir: str | Path,
@@ -149,7 +161,7 @@ def batch(
         crop_kwargs=crop_kwargs,
         carry_on=carry_on,
     )
-    return ",".join(processed_filenames)
+    print(",".join(processed_filenames))
 
 
 if __name__ == "__main__":

--- a/flfm/cli.py
+++ b/flfm/cli.py
@@ -11,6 +11,8 @@ import flfm.util  # noqa:  F401
 from flfm.backend import reload_backend
 from flfm.settings import settings
 
+from batch import batch_reconstruction
+
 ERR_BACKEND_MSSG = "FLFM {backend} not found ❌"
 BACKEND_SUCCESS = "FLFM {backend} loaded ✅"
 
@@ -104,10 +106,57 @@ def export(
     )
 
 
+def batch(
+        input_dir: str | Path,
+        output_dir: str | Path,
+        psf_filename: str | Path,
+        normalize_psf: bool = True,
+        n_workers: Optional[int] = None,
+        n_threads: int = 2,
+        clobber: bool = False,
+        recon_kwargs: Optional[dict] = None,
+        crop_kwargs: Optional[dict] = None,
+        carry_on: bool = False
+)-> list[Path]:
+    """Batch parallel process multiple 3D reconstructions of input light-field images present in `input_dir`.
+
+        Args:
+            input_dir: Input directory.
+            output_dir: Output directory.
+            psf_filename: PSF filename.
+            normalize_psf: Whether to normalize PSF before reconstruction. Defaults to True.
+            n_workers: Numbers of parallel workers.  Defaults to None.
+            n_threads: Number of threads per worker.  Defaults to 2.
+            clobber: Write over files in `output_dir`, otherwise raise if `output_dir` exists.
+                Defaults to `False`.
+            recon_kwargs: kwargs passed to `richardson_lucy()`.  Defaults to None.
+            crop_kwargs: kwargs pass to `flfm.util.crop_and_apply_circle_mask()`. Defaults to None.
+            carry_on: Whether to continue processing from a previous attempt. Will only process input
+                files not in `output_dir`.  Defaults to False.
+
+        Returns:
+           A comma seperated string of processed filenames.
+        """
+    processed_filenames = batch_reconstruction(
+        input_dir,
+        output_dir,
+        psf_filename,
+        normalize_psf=normalize_psf,
+        n_workers=n_workers,
+        n_threads=n_threads,
+        clobber=clobber,
+        recon_kwargs=recon_kwargs,
+        crop_kwargs=crop_kwargs,
+        carry_on=carry_on,
+    )
+    return ",".join(processed_filenames)
+
+
 if __name__ == "__main__":
     fire.Fire(
         {
             "main": main,
+            "batch": batch,
             "export": export,
         }
     )

--- a/flfm/cli.py
+++ b/flfm/cli.py
@@ -30,7 +30,13 @@ def import_backend(backend: str) -> None:
         print(BACKEND_SUCCESS.format(backend=backend))
 
 
-def exception_handler(debug):
+def exception_handler(debug: bool):
+    """Command line exception handler
+
+    Args:
+        debug: Raises exceptions if True and prints exception message if False.
+    """
+
     def decorator(func):
         def wrapper(*args, **kwargs):
             try:

--- a/flfm/cli.py
+++ b/flfm/cli.py
@@ -6,12 +6,11 @@ from pathlib import Path
 from typing import Literal, Optional
 
 import fire
+from batch import batch_reconstruction
 
 import flfm.util  # noqa:  F401
 from flfm.backend import reload_backend
 from flfm.settings import settings
-
-from batch import batch_reconstruction
 
 ERR_BACKEND_MSSG = "FLFM {backend} not found ❌"
 BACKEND_SUCCESS = "FLFM {backend} loaded ✅"
@@ -37,6 +36,7 @@ def exception_handler(func):
             return func(*args, **kwargs)
         except Exception as error:
             print(error)
+
     return wrapper
 
 
@@ -119,36 +119,36 @@ def export(
 
 @exception_handler
 def batch(
-        input_dir: str | Path,
-        output_dir: str | Path,
-        psf_filename: str | Path,
-        normalize_psf: bool = True,
-        n_workers: Optional[int] = None,
-        n_threads: int = 2,
-        clobber: bool = False,
-        recon_kwargs: Optional[dict] = None,
-        crop_kwargs: Optional[dict] = None,
-        carry_on: bool = False
-)-> list[Path]:
+    input_dir: str | Path,
+    output_dir: str | Path,
+    psf_filename: str | Path,
+    normalize_psf: bool = True,
+    n_workers: Optional[int] = None,
+    n_threads: int = 2,
+    clobber: bool = False,
+    recon_kwargs: Optional[dict] = None,
+    crop_kwargs: Optional[dict] = None,
+    carry_on: bool = False,
+) -> list[Path]:
     """Batch parallel process multiple 3D reconstructions of input light-field images present in `input_dir`.
 
-        Args:
-            input_dir: Input directory.
-            output_dir: Output directory.
-            psf_filename: PSF filename.
-            normalize_psf: Whether to normalize PSF before reconstruction. Defaults to True.
-            n_workers: Numbers of parallel workers.  Defaults to None.
-            n_threads: Number of threads per worker.  Defaults to 2.
-            clobber: Write over files in `output_dir`, otherwise raise if `output_dir` exists.
-                Defaults to `False`.
-            recon_kwargs: kwargs passed to `richardson_lucy()`.  Defaults to None.
-            crop_kwargs: kwargs pass to `flfm.util.crop_and_apply_circle_mask()`. Defaults to None.
-            carry_on: Whether to continue processing from a previous attempt. Will only process input
-                files not in `output_dir`.  Defaults to False.
+    Args:
+        input_dir: Input directory.
+        output_dir: Output directory.
+        psf_filename: PSF filename.
+        normalize_psf: Whether to normalize PSF before reconstruction. Defaults to True.
+        n_workers: Numbers of parallel workers.  Defaults to None.
+        n_threads: Number of threads per worker.  Defaults to 2.
+        clobber: Write over files in `output_dir`, otherwise raise if `output_dir` exists.
+            Defaults to `False`.
+        recon_kwargs: kwargs passed to `richardson_lucy()`.  Defaults to None.
+        crop_kwargs: kwargs pass to `flfm.util.crop_and_apply_circle_mask()`. Defaults to None.
+        carry_on: Whether to continue processing from a previous attempt. Will only process input
+            files not in `output_dir`.  Defaults to False.
 
-        Returns:
-           A comma seperated string of processed filenames.
-        """
+    Returns:
+       A comma seperated string of processed filenames.
+    """
     processed_filenames = batch_reconstruction(
         input_dir,
         output_dir,

--- a/flfm/settings.py
+++ b/flfm/settings.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     DEFAULT_CENTER_X: int = 1000
     DEFAULT_CENTER_Y: int = 980
     DEFAULT_RADIUS: int = 230
+    DEBUG_CLI: bool = False
 
 
 class AppSettings(BaseSettings):

--- a/flfm/tests/test_batch.py
+++ b/flfm/tests/test_batch.py
@@ -54,7 +54,6 @@ def mock_data(tmp_path):
     return output_dir
 
 
-@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Runs out of memory.")
 class TestBatchReconstruction:
     def test_mock_data(self, mock_data):
         assert len(list(mock_data.glob("*.tif"))) == n_copies

--- a/flfm/tests/test_batch.py
+++ b/flfm/tests/test_batch.py
@@ -48,7 +48,7 @@ def mock_data(tmp_path):
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Assert empty.
-    assert not flfm.util.find_files(output_dir)
+    assert not list(output_dir.glob("*.tif"))
 
     mock_batch_data(input_filename, output_dir, n_copies)
     return output_dir
@@ -57,7 +57,7 @@ def mock_data(tmp_path):
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Runs out of memory.")
 class TestBatchReconstruction:
     def test_mock_data(self, mock_data):
-        assert len(flfm.util.find_files(mock_data)) == n_copies
+        assert len(list(mock_data.glob("*.tif"))) == n_copies
 
     def test_batch_reconstruction(self, mock_data):
         input_dir = mock_data
@@ -65,11 +65,11 @@ class TestBatchReconstruction:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Assert empty.
-        assert not flfm.util.find_files(output_dir)
+        assert not list(output_dir.glob("*.tif"))
 
         # Reduce memory consumption by only using half the # of CPUs.
         processed_files = batch_reconstruction(input_dir, output_dir, psf_filename, clobber=True, n_workers=n_workers)
-        assert len(flfm.util.find_files(mock_data)) == n_copies
+        assert len(list(mock_data.glob("*.tif"))) == n_copies
         assert len(processed_files) == n_copies
 
     def test_carry_on(self, mock_data):
@@ -78,21 +78,21 @@ class TestBatchReconstruction:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Assert empty.
-        assert not flfm.util.find_files(output_dir)
+        assert not list(output_dir.glob("*.tif"))
 
         # Copy half data to mock in complete initial run.
-        files = flfm.util.find_files(input_dir)
+        files = list(input_dir.glob("*.tif"))
         for i, filename in enumerate(files):
             if i >= len(files) // 2:
                 break
             shutil.copy(filename, output_dir / filename.name)
 
-        assert len(flfm.util.find_files(output_dir)) == n_copies // 2
+        assert len(list(output_dir.glob("*.tif"))) == n_copies // 2
 
         # Reduce memory consumption by only using half the # of CPUs.
         processed_files = batch_reconstruction(
             input_dir, output_dir, psf_filename, clobber=True, n_workers=2, carry_on=True
         )
 
-        assert len(flfm.util.find_files(mock_data)) == n_copies
+        assert len(list(mock_data.glob("*.tif"))) == n_copies
         assert len(processed_files) == len(files) - len(files) // 2

--- a/flfm/tests/test_batch.py
+++ b/flfm/tests/test_batch.py
@@ -54,6 +54,7 @@ def mock_data(tmp_path):
     return output_dir
 
 
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Runs out of memory.")
 class TestBatchReconstruction:
     def test_mock_data(self, mock_data):
         assert len(list(mock_data.glob("*.tif"))) == n_copies

--- a/flfm/tests/test_cli.py
+++ b/flfm/tests/test_cli.py
@@ -57,3 +57,18 @@ class TestCli:
             assert out_stream.is_file() and out_stream.suffix == ".pt"
         else:
             assert not out_stream.is_file()
+
+    def test_cli_batch(self, tmp_path: Path, backend: str):
+        """Test the batch command line interface."""
+        out_dir = tmp_path / "batched_files"
+
+        # Assert out dir starts empty.
+        assert not list(out_dir.glob("*"))
+
+        filename_pattern = "light*.tif"
+        input_dir = flfm.util.find_package_location() / "tests" / "data" / "yale"
+        flfm.cli.batch(
+            input_dir, out_dir, input_dir / "measured_psf.tif", filename_pattern=filename_pattern, n_workers=1
+        )
+
+        assert len(list(out_dir.glob("*"))) == len(list(input_dir.glob(filename_pattern)))

--- a/flfm/util.py
+++ b/flfm/util.py
@@ -74,27 +74,6 @@ def crop_and_apply_circle_mask(
     return sub_O * circle_mask  # [k, 2 * radius, 2 * radius]
 
 
-def find_files(directory: str | Path, ext: str | None = None) -> list[Path]:
-    """Find all files in a directory, filter on ext if given.
-
-    Args:
-        directory: The directory to search.
-        ext: The extension to filter on.
-
-    Returns:
-        A list of files.
-    """
-    directory = Path(directory)
-    file_list = []
-    for file in directory.iterdir():
-        if (ext is not None) and (not file.suffix == ext):
-            continue
-        full_path = directory / file
-        if full_path.is_file():
-            file_list.append(full_path.absolute())
-    return file_list
-
-
 def setup_logging(level: str = settings.LOG_LEVEL, format: str = settings.LOG_FORMAT, **kwargs):
     """Set up logging.
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,5 @@
 from flfm import __project__, __version__
-from flfm.util import find_files, find_package_location, find_repo_location
+from flfm.util import find_package_location, find_repo_location
 
 
 def test_find_repo_location():
@@ -29,11 +29,3 @@ def test_version():
 
 def test_project():
     assert __project__
-
-
-def test_find_files():
-    filenames = find_files(find_package_location() / "tests" / "data" / "yale")
-    assert len(filenames) == 3
-
-    filenames = find_files(find_package_location() / "tests" / "data" / "yale", ext=".txt")
-    assert len(filenames) == 1


### PR DESCRIPTION
Resolves #192 

Also includes:
-  Adds exception handler to cli to only print error messages and not dump tracebacks.
- Add ``FLFM_DEBUG_CLI`` env setting to toggle the above exception handling.
- Nukes ``flfm.util.find_files`` and uses ``pathlib.Path.glob`` instead.
- Adds ``filename_pattern`` to ``flfm.batch.batch_reconstruction``.
- Raises an exception on empty input dir.
