### PR TITLE
Limit JAX GPU memory preallocation

### DIFF
--- a/flfm/backend/jax.py
+++ b/flfm/backend/jax.py
@@ -1,5 +1,6 @@
 """FLFM observation reconstruction using JAX."""
 
+import os
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -9,6 +10,10 @@ from numpy.typing import ArrayLike
 from PIL import Image
 
 from flfm.backend.base import BaseIO, BaseRestoration
+from flfm.settings import settings
+
+# See https://docs.jax.dev/en/latest/gpu_memory_allocation.html
+os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = str(settings.GPU_MEMORY_PREALLOCATION).lower()
 
 
 def rl_step(

--- a/flfm/settings.py
+++ b/flfm/settings.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     DEFAULT_CENTER_Y: int = 980
     DEFAULT_RADIUS: int = 230
     DEBUG_CLI: bool = False
+    GPU_MEMORY_PREALLOCATION: bool = False  # Only applicable for BACKEND = "jax".
 
 
 class AppSettings(BaseSettings):


### PR DESCRIPTION
Resolves #151 
Relates to #169

Jax's default GPU memory preallocation consumption is 75%. This PR toggles this functionality using the env var ``XLA_PYTHON_CLIENT_PREALLOCATE``.

When testing this on our 80GB A100 with preallocation ON, the max memory footprint is ~60GB as expected. With it toggled OFF, the max memory footprint is ~8.6GB.

Jax docs:

- https://docs.jax.dev/en/latest/gpu_memory_allocation.html
- https://docs.jax.dev/en/latest/config_options.html

Extremely crude profiling confirmed that this works. Running and observing ``nvidia-smi -lms=10`` whilst also running ``python flfm/cli.py main /data/yale/light_field_image.tif /data/yale/measured_psf.tif reconstructed_image.tiff --normalize_psf=True --lens_radius=230 --lens_center="(1000,980)" --backend=jax``.

Max mem footprint observed with ``FLFM_GPU_MEMORY_PREALLOCATION=true``
<img width="752" height="476" alt="Screenshot 2025-07-24 at 5 58 04 PM" src="https://github.com/user-attachments/assets/ae86713a-bc0c-40e4-86fd-3219db76059b" />

> [!NOTE]  
>  ``81920 * 0.75 = 61440 ~= 61212`` as observered.

Max mem footprint observed with ``FLFM_GPU_MEMORY_PREALLOCATION=false``
<img width="759" height="478" alt="Screenshot 2025-07-24 at 6 02 41 PM" src="https://github.com/user-attachments/assets/bc2f7c14-f2a6-4f81-b773-4ae3819cc71c" />
