### PR TITLE
Fix failing readthedocs build regressed by #193

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ extensions = [
 
 autoapi_dirs = ['../../flfm']
 autoapi_add_toctree_entry = True
-autoapi_ignore = ['*test*']
+autoapi_ignore = ['*test*', '_version']
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ extensions = [
 
 autoapi_dirs = ['../../flfm']
 autoapi_add_toctree_entry = True
-autoapi_ignore = ['*test*', '_version']
+autoapi_ignore = ['*tests*', '_version.py']
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),


### PR DESCRIPTION
Relates to #203.

Addressing #203 may require some trial and error shenanigans since the docs build locally, during CI on GitHub actions, and on RTD for the PR but _not_ on RTD post merge.