### PR TITLE
Fix typo from #193 to ignore _version.py from docs api

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ extensions = [
 
 autoapi_dirs = ['../../flfm']
 autoapi_add_toctree_entry = True
-autoapi_ignore = ['*tests*', '_version.py']
+autoapi_ignore = ['*tests*', '*_version.py']
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),


### PR DESCRIPTION
Whoops, missed this in #193 

Before:
<img width="1112" height="837" alt="Screenshot 2025-08-05 at 7 52 10 AM" src="https://github.com/user-attachments/assets/0c66e467-e549-4de6-89c1-5f01a6ceab67" />

After (this PR):
<img width="1069" height="813" alt="Screenshot 2025-08-05 at 7 51 20 AM" src="https://github.com/user-attachments/assets/1313ddcc-a91b-4fa1-966f-171295f60e9e" />
